### PR TITLE
Add DeepAlpha - AI crypto trading bot with 70.9% accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Giller, Graham L. Adventures in Financial Data Science: The empirical properties
 
 ### Machine Learning
 
+- [DeepAlpha](https://github.com/stefanoviana/deepalpha) - AI crypto trading bot with 70.9% walk-forward validated accuracy. XGBoost + LightGBM ensemble with 72 features. MIT license.
+
 |  Project | Stars | Recommendation | Description |
 |---|---|---|-------------|
 |[ML for Trading](https://github.com/stefan-jansen/machine-learning-for-trading)| 6.6k | :star::star::star::star::star: | A book shows how ML can add value to algorithmic trading strategies in a practical yet comprehensive way|


### PR DESCRIPTION
## Description

Adding [DeepAlpha](https://github.com/stefanoviana/deepalpha) to this awesome list.

**DeepAlpha** is an open-source AI-powered crypto trading bot featuring:
- 70.9% walk-forward validated accuracy
- XGBoost + LightGBM ensemble with 72 engineered features
- Support for Bybit and Binance via CCXT
- MIT licensed
- Active development with 11+ model versions

## Checklist
- [x] Entry follows the existing format
- [x] Project is open source (MIT license)
- [x] Project is actively maintained
- [x] Description is concise and accurate
