### PR TITLE
feat: add The Stall — x402 MCP server with 173 financial market data capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Tools and APIs for accessing financial market data — stocks, crypto, forex, an
 | [jqdatasdk](https://github.com/JoinQuant/jqdatasdk) | 1.3k ![Stars](https://img.shields.io/github/stars/JoinQuant/jqdatasdk?style=flat-square) | JoinQuant's Python data SDK for Chinese financial market data. |
 | [DeFiLlama Adapters](https://github.com/DefiLlama/DefiLlama-Adapters) | 1.2k ![Stars](https://img.shields.io/github/stars/DefiLlama/DefiLlama-Adapters?style=flat-square) | Open-source DeFi TVL calculation adapters for 2,400+ protocols across 180+ blockchains. |
 | [WRDS](https://github.com/wharton/wrds) | 155 ![Stars](https://img.shields.io/github/stars/wharton/wrds?style=flat-square) | Python interface to Wharton Research Data Services for academic financial research. |
+| [The Stall](https://github.com/thebrierfox/the-stall) | ![Stars](https://img.shields.io/github/stars/thebrierfox/the-stall?style=flat-square) | MCP server with 173 financial market data capabilities — stocks, ETFs, crypto, DeFi, options, SEC filings, earnings, analyst ratings, and macro indicators. Pay-per-call via x402 micropayments on Base; no API keys required. |
 
 ---
 


### PR DESCRIPTION
## What is this?

[The Stall](https://github.com/thebrierfox/the-stall) is an open-source MCP server that gives AI agents access to 173 financial market data capabilities via x402 micropayments on Base.

### Why it belongs in Data Sources

- **173 financial data capabilities** — stocks, ETFs, crypto, DeFi, options chains, SEC filings, earnings, analyst ratings, insider trades, hedge fund holdings, macro indicators, and more
- **MCP-native** — plug directly into Claude, Cursor, and any MCP-compatible AI agent
- **No API keys required** — pay per call in USDC on Base via the [x402 protocol](https://github.com/x402-foundation/x402)
- **Open source** — all capability code is public at github.com/thebrierfox/the-stall

### Relevant capabilities

| Category | Examples |
|----------|---------|
| Equities | `us-stock-price`, `equity-fundamentals`, `earnings-surprises`, `analyst-ratings` |
| ETF/Funds | `etf-holdings`, `hedge-fund-holdings`, `insider-trades` |
| Crypto | `crypto-fear-greed`, `crypto-pulse`, `defi-market-pulse`, `polymarket-intel` |
| Macro | `treasury-yields`, `imf-country-outlook`, `economic-calendar`, `fomc-tracker` |
| SEC | `sec-filing-intel`, `sec-insider-trades`, `congressional-trades` |
| Prediction | `prediction-markets`, `polymarket-accuracy-score` |

The Stall is infrastructure for AI agents doing autonomous financial analysis — the kind of tooling that AI4Finance's ecosystem is built to enable.