### PR TITLE
Add Superhighway - M&A research agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Autonomous AI agents that can analyze markets, make trading decisions, and gener
 | [QuantaAlpha](https://github.com/QuantaAlpha/QuantaAlpha) | 1.0k ![Stars](https://img.shields.io/github/stars/QuantaAlpha/QuantaAlpha?style=flat-square) | LLM + evolutionary strategies framework for automatic alpha factor mining. |
 | [FinMem](https://github.com/pipiku915/FinMem-LLM-StockTrading) | 903 ![Stars](https://img.shields.io/github/stars/pipiku915/FinMem-LLM-StockTrading?style=flat-square) | LLM-based trading agent with layered memory (short/mid/long-term) for evolving market understanding. |
 | [QVeris](https://github.com/QVerisAI/qveris-agent-toolkit) | 230 ![Stars](https://img.shields.io/github/stars/QVerisAI/qveris-agent-toolkit?style=flat-square) | Capability routing network for AI agents to discover, inspect, and call 10,000+ real-world financial capabilities through one unified MCP protocol. |
+| [Superhighway M&A Research Agent](https://superhighway.walls.sh/guides/ma-research-agent) | – | Python agent that researches comparable M&A transactions, deal multiples, potential acquirers, and recent deal activity via live web search. Generates structured M&A intelligence briefs for corporate development, PE analysts, and investment bankers. Pay-per-call, no signup. |
 
 ---
 


### PR DESCRIPTION
Adds Superhighway's M&A research agent guide — a Python agent that researches comparable M&A transactions, deal multiples, potential acquirers, and recent M&A deal activity using live web search (/search, /scrape, /research, /news). Outputs structured M&A intelligence briefs with strategic rationale, comparable transactions, valuation multiples, regulatory considerations, and due diligence flags. Audience: corporate development, PE analysts, investment bankers, founders mapping exit paths. Pay-per-call, no signup. https://superhighway.walls.sh/guides/ma-research-agent